### PR TITLE
Jden support interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "repository": "git@github.com:kurttheviking/bluecache.git",
   "dependencies": {
     "bluebird": "^2.9.24",
+    "interval": "0.0.9",
     "lru-cache": "2.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": "git@github.com:kurttheviking/bluecache.git",
   "dependencies": {
-    "bluebird": "2.3.11",
+    "bluebird": "^2.9.24",
     "lru-cache": "2.5.0"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,14 @@ describe('bluecache ->', function () {
     });
   });
 
+  describe('options ->', function () {
+    it('accepts `interval` timespans', function () {
+      var bcache = new BlueLRU({maxAge: {days: 5}});
+      chai.expect(bcache._lrucache._maxAge).to.equal(5 * 24 * 60 * 60 * 1000);
+    })
+
+  })
+
   describe('deletes ->', function () {
     var bcache = new BlueLRU();
 


### PR DESCRIPTION
be able to replace
```js

var cache = new BlueLRU({
  max: 4096,
  maxAge: 5 * 60 * 1000  // [KE] 5 minutes
});
```

with 

```js

var cache = new BlueLRU({
  max: 4096,
  maxAge: {minutes: 5}
});
```

uses the [interval](https://npmjs.com/interval) package